### PR TITLE
Refactor Strings to DateComponents, fix Next Period not showing, update schedules JSON

### DIFF
--- a/Shared/Code/DateTime.swift
+++ b/Shared/Code/DateTime.swift
@@ -7,6 +7,17 @@
 
 import Foundation
 
+
+extension Date {
+    
+    /// only keep hour, min, sec
+    func keepOnlyTime() -> DateComponents {
+        let timeComponents = Calendar.current.dateComponents([.hour, .minute, .second], from: self)
+        return timeComponents
+    }
+}
+
+
 func getCurrentDay() -> Days? {
     let date = Date()
     let formatter = DateFormatter()
@@ -20,23 +31,10 @@ func getCurrentDay() -> Days? {
     }
 }
 
-func getSplitTime() -> String {
-    let date = Date()
-    let formatter = DateFormatter()
-
-    formatter.dateFormat = "HH-mm-ss"
-    return formatter.string(from: date)
-}
-
-func calculateTimeDifference(startTimeString: String, endTimeString: String) -> (hour: Int?, minute: Int?, second: Int?) {
-    let formatter = DateFormatter()
-    formatter.dateFormat = "HH-mm-ss"
-
-    if let startTime = formatter.date(from: startTimeString), let endTime = formatter.date(from: endTimeString) {
-        return endTime - startTime
-    } else {
-        return (nil, nil, nil)
-    }
+/// difference between 2 date components
+func calculateTimeDifference(startTimeComponents: DateComponents, endTimeComponents: DateComponents) -> (hour: Int?, minute: Int?, second: Int?) {
+    let difference = Calendar.current.dateComponents([.hour, .minute, .second], from: startTimeComponents, to: endTimeComponents)
+    return (difference.hour, difference.minute, difference.second)
 }
 
 func is24Hour() -> Bool {

--- a/Shared/Code/JSONParser.swift
+++ b/Shared/Code/JSONParser.swift
@@ -10,31 +10,56 @@ import SwiftyJSON
 
 func importSchedule(scheduleData: Data) -> [Schedule] {
     var schedules = [Schedule]()
-
+    
     do {
         let json = try JSON(data: scheduleData)
-
+        
         for (key, value): (String, JSON) in json {
             var allPeriods = [Day]()
             for (day, periods): (String, JSON) in value["schedule"] {
                 var dayPeriods = [Period]()
-
+                
                 for (periodName, periodTimes): (String, JSON) in periods {
-                    dayPeriods.append(Period(name: periodName, startTime: periodTimes[0].stringValue, endTime: periodTimes[1].stringValue))
+                    let dateFormatter = DateFormatter()
+                    dateFormatter.dateFormat = "HH-mm-ss"
+                    
+                    let startTimeString = periodTimes[0].stringValue
+                    let endTimeString = periodTimes[1].stringValue
+                    
+                    if
+                        let startDate = dateFormatter.date(from: startTimeString),
+                        let endDate = dateFormatter.date(from: endTimeString)
+                        
+                        
+                        
+                    {
+                        /// only use hour, min, sec
+                        let startTimeComponents = startDate.keepOnlyTime()
+                        let endTimeComponents = endDate.keepOnlyTime()
+                        
+                        dayPeriods.append(
+                            Period(
+                                name: periodName,
+                                startTimeComponents: startTimeComponents,
+                                endTimeComponents: endTimeComponents
+                            )
+                        )
+                    }
                 }
-
+                
                 if ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"].contains(day) {
                     if let dayCase = Days(rawValue: day) {
                         allPeriods.append(Day(day: dayCase, periods: dayPeriods))
                     }
                 }
             }
-
+            
+//            print("Datys: \(allPeriods)")
             let schedule = Schedule(id: key, name: value["name"].stringValue, shortName: value["shortName"].stringValue, icon: value["icon"].stringValue, color: value["color"].stringValue, schedule: allPeriods)
-
+            
             schedules.append(schedule)
         }
-
+        
         return schedules
     } catch {
         return []

--- a/Shared/Code/Schedule.swift
+++ b/Shared/Code/Schedule.swift
@@ -11,36 +11,56 @@ func getDaySchedule(schedule: [Day]) -> Day? {
     if let currentDay = getCurrentDay(), let daySchedule = schedule.first(where: { $0.day == currentDay }) {
         return daySchedule
     }
-
+    
     return nil
 }
 
 func getCurrentPeriod(schedule: [Day]) -> Period? {
-    if let daySchedule = getDaySchedule(schedule: schedule), let time = Int(getSplitTime().replacingOccurrences(of: "-", with: "")) {
-        for period in daySchedule.periods {
-            if let periodStart = Int(period.startTime.replacingOccurrences(of: "-", with: "")), let periodEnd = Int(period.endTime.replacingOccurrences(of: "-", with: "")) {
-                if periodStart <= time, time <= periodEnd {
-                    return period
-                }
+    
+    if let daySchedule = getDaySchedule(schedule: schedule) {
+        let currentTimeComponents = Date().keepOnlyTime()
+        
+        /// return first occurrence of a period,
+        /// where the current time is within its start and end.
+        return daySchedule.periods.first { period in
+            if
+                let startDate = Calendar.current.date(from: period.startTimeComponents),
+                let endDate = Calendar.current.date(from: period.endTimeComponents),
+                let currentDate = Calendar.current.date(from: currentTimeComponents)
+            {
+                return (startDate ... endDate).contains(currentDate)
             }
+            
+            return false
         }
     }
-
+    
     return nil
 }
 
 func getNextPeriod(schedule: [Day]) -> Period? {
-    if let daySchedule = getDaySchedule(schedule: schedule), let currentEndTimeRaw = (getCurrentPeriod(schedule: schedule)?.endTime.format(template: "HH-mm-ss")?.addingTimeInterval(1).format(template: "HH-mm-ss")) {
-        let currentEndTime = Int(currentEndTimeRaw.replacingOccurrences(of: "-", with: ""))
+    if let daySchedule = getDaySchedule(schedule: schedule) {
+        if let currentPeriod = getCurrentPeriod(schedule: schedule) {
+            
+            /// return first occurrence of period,
+            /// where its `startTimeComponents` matches this current period's `endTimeComponents`.
+            return daySchedule.periods.first { nextPeriod in
+                
+                if /// convert time components to dates for comparing
+                    let currentPeriodEndDate = Calendar.current.date(from: currentPeriod.endTimeComponents),
+                    let nextPeriodStartDate = Calendar.current.date(from: nextPeriod.startTimeComponents)
+                {
+                    
+                    let (tdHour, tdMinute, tdSecond) = nextPeriodStartDate - currentPeriodEndDate
 
-        for period in daySchedule.periods {
-            if let periodStart = Int(period.startTime.replacingOccurrences(of: "-", with: "")) {
-                if periodStart == currentEndTime {
-                    return period
+                    /// the next period has an offset of 1 second, need to account for that
+                    return tdHour == 0 && tdMinute == 0 && tdSecond == 1
                 }
+                
+                return false
             }
         }
     }
-
+    
     return nil
 }

--- a/Shared/Code/Structures.swift
+++ b/Shared/Code/Structures.swift
@@ -30,8 +30,8 @@ struct Day: Hashable {
 
 struct Period: Hashable {
     let name: String
-    let startTime: String
-    let endTime: String
+    let startTimeComponents: DateComponents
+    let endTimeComponents: DateComponents
 }
 
 // MARK: - Enumerations

--- a/Shared/Views/ScheduleView.swift
+++ b/Shared/Views/ScheduleView.swift
@@ -42,8 +42,10 @@ struct ScheduleView: View {
     func updateSchedule() {
         if let currentPeriod = getCurrentPeriod(schedule: schedule.schedule) {
             currentPeriodName = currentPeriod.name
-
-            let (tdHour, tdMinute, tdSecond) = calculateTimeDifference(startTimeString: getSplitTime(), endTimeString: currentPeriod.endTime)
+            
+            let currentTimeComponents = Date().keepOnlyTime()
+            let (tdHour, tdMinute, tdSecond) = calculateTimeDifference(startTimeComponents: currentTimeComponents, endTimeComponents: currentPeriod.endTimeComponents)
+            
             if let hour = tdHour, let minute = tdMinute, let second = tdSecond {
                 timeRemaining = "\(String(format: "%02d", hour)):\(String(format: "%02d", minute)):\(String(format: "%02d", second))"
 
@@ -77,7 +79,18 @@ struct ScheduleView: View {
 
         if let nextPeriod = getNextPeriod(schedule: schedule.schedule) {
             nextPeriodName = nextPeriod.name
-            nextPeriodStartingTime = nextPeriod.startTime.format(template: "HH-mm-ss")?.format(template: is24Hour() ? "HH:mm" : "h:mm a") ?? "00:00"
+            
+            let dateFormatter = DateFormatter()
+            if is24Hour() {
+                dateFormatter.dateFormat = "h:mm a"
+            } else {
+                dateFormatter.dateFormat = "HH:mm"
+            }
+            
+            if let nextPeriodStartDate = Calendar.current.date(from: nextPeriod.startTimeComponents) {
+                let nextPeriodStartingTimeString = dateFormatter.string(from: nextPeriodStartDate)
+                nextPeriodStartingTime = nextPeriodStartingTimeString
+            }
         }
     }
 
@@ -108,7 +121,27 @@ struct ScheduleView: View {
 #if DEBUG
 struct ScheduleView_Previews: PreviewProvider {
     static var previews: some View {
-        ScheduleView(schedule: Schedule(id: "sch-demo-abc", name: "Demo Schedule", shortName: "Demo", icon: "mdiTestTube", color: "#13323C", schedule: [Day(day: .monday, periods: [Period(name: "Demo Period I", startTime: "08-30-00", endTime: "15-20-00")])]))
+        ScheduleView(
+            schedule: Schedule(
+                id: "sch-demo-abc",
+                name: "Demo Schedule",
+                shortName: "Demo",
+                icon: "mdiTestTube",
+                color: "#13323C",
+                schedule: [
+                    Day(
+                        day: .monday,
+                        periods: [
+                            Period(
+                                name: "Demo Period I",
+                                startTimeComponents: DateComponents(hour: 8, minute: 30),
+                                endTimeComponents: DateComponents(hour: 15, minute: 20)
+                            )
+                        ]
+                    )
+                ]
+            )
+        )
     }
 }
 #endif

--- a/Shared/schedules.json
+++ b/Shared/schedules.json
@@ -6,181 +6,80 @@
         "color": "#343254",
         "schedule": {
             "MON": {
-                "1st Period": ["08-35-00", "09-20-00"],
-                "Passing: 1/2": ["09-20-01", "09-25-00"],
-                "2nd Period": ["09-25-01", "10-10-00"],
-                "Passing: 2/3": ["10-10-01", "10-15-00"],
-                "3rd Period": ["10-15-01", "11-00-00"],
-                "Brunch": ["11-00-01", "11-10-00"],
-                "Passing: Brunch/4": ["11-10-01", "11-15-00"],
-                "4th Period": ["11-15-01", "12-00-00"],
-                "Passing: 4/5": ["12-00-01", "12-05-00"],
-                "5th Period": ["12-05-01", "12-50-00"],
+                "Zero Period": ["07-15-00", "08-30-00"],
+                "Passing (Zero / First Periods)": ["08-30-01", "08-35-00"],
+                "First Period": ["08-35-01", "09-20-00"],
+                "Passing (First / Second Periods)": ["09-20-01", "09-25-00"],
+                "Second Period": ["09-25-01", "10-10-00"],
+                "Passing (Second / Third Periods)": ["10-10-01", "10-15-00"],
+                "Third Period": ["10-15-01", "11-00-00"],
+                "Brunch": ["11-00-01", "11-15-00"],
+                "Fourth Period": ["11-15-01", "12-00-00"],
+                "Passing (Fourth / Fifth Periods)": ["12-00-01", "12-05-00"],
+                "Fifth Period": ["12-05-01", "12-50-00"],
                 "Lunch": ["12-50-01", "13-25-00"],
-                "Passing: Lunch/6": ["13-25-01", "13-30-00"],
-                "6th Period": ["13-30-01", "14-15-00"],
-                "Passing: 6/7": ["14-15-01", "14-20-00"],
-                "7th Period": ["14-20-01", "15-05-00"]
+                "Passing (Lunch / Sixth Period)": ["13-25-01", "13-30-00"],
+                "Sixth Period": ["13-30-01", "14-15-00"],
+                "Passing (Sixth / Seventh Periods)": ["14-15-01", "14-20-00"],
+                "Seventh Period": ["14-20-01", "15-05-00"]
             },
             "TUE": {
-                "1st Period": ["08-00-00", "09-30-00"],
-                "Passing: 1/2": ["09-30-01", "09-40-00"],
-                "2nd Period": ["09-40-01", "11-10-00"],
+                "Zero Period": ["07-00-00", "07-50-00"],
+                "Passing (Zero / First Period)": ["07-50-01", "08-00-00"],
+                "First Period": ["08-00-01", "09-30-00"],
+                "Passing (First / Second Periods)": ["09-30-01", "09-40-00"],
+                "Second Period": ["09-40-01", "11-10-00"],
                 "Brunch": ["11-10-01", "11-15-00"],
-                "Passing: Brunch/3": ["11-15-01", "11-25-00"],
-                "3rd Period": ["11-25-01", "12-55-00"],
+                "Passing (Brunch / Third Period)": ["11-15-01", "11-25-00"],
+                "Third Period": ["11-25-01", "12-55-00"],
                 "Lunch": ["12-55-01", "13-25-00"],
-                "Passing: Lunch/7": ["13-25-01", "13-35-00"],
-                "7th Period": ["13-35-01", "15-05-00"]
+                "Passing (Lunch / Seventh Period)": ["13-25-01", "13-35-00"],
+                "Seventh Period": ["13-35-01", "15-05-00"]
             },
             "WED": {
-                "4th Period": ["08-00-00", "10-05-00"],
-                "Passing: 4/Academy": ["10-05-01", "10-15-00"],
+                "Staff Meeting": ["07-30-00", "08-30-00"],
+                "Passing (Staff Meeting / Fourth Periods)": [
+                    "08-30-01",
+                    "08-35-00"
+                ],
+                "Fourth Period": ["08-35-01", "10-05-00"],
+                "Passing (Fourth Period / Academy)": ["10-05-01", "10-15-00"],
                 "Academy": ["10-15-01", "11-10-00"],
                 "Brunch": ["11-10-01", "11-15-00"],
-                "Passing: Brunch/5": ["11-15-01", "11-25-00"],
-                "5th Period": ["11-25-01", "12-55-00"],
+                "Passing (Brunch / Fifth Period)": ["11-15-01", "11-25-00"],
+                "Fifth Period": ["11-25-01", "12-55-00"],
                 "Lunch": ["12-55-01", "13-25-00"],
-                "Passing: Lunch/6": ["13-25-01", "13-35-00"],
-                "6th Period": ["13-35-01", "15-05-00"]
+                "Passing (Lunch / Sixth Period)": ["13-25-01", "13-35-00"],
+                "Sixth Period": ["13-35-01", "15-05-00"]
             },
             "THU": {
-                "1st Period": ["08-00-00", "09-30-00"],
-                "Passing: 1/2": ["09-30-01", "09-40-00"],
-                "2nd Period": ["09-40-01", "11-10-00"],
+                "Zero Period": ["07-00-00", "07-50-00"],
+                "Passing (Zero / First Period)": ["07-50-01", "08-00-00"],
+                "First Period": ["08-00-01", "09-30-00"],
+                "Passing (First / Second Periods)": ["09-30-01", "09-40-00"],
+                "Second Period": ["09-40-01", "11-10-00"],
                 "Brunch": ["11-10-01", "11-15-00"],
-                "Passing: Brunch/3": ["11-15-01", "11-25-00"],
-                "3rd Period": ["11-25-01", "12-55-00"],
+                "Passing (Brunch / Third Period)": ["11-15-01", "11-25-00"],
+                "Third Period": ["11-25-01", "12-55-00"],
                 "Lunch": ["12-55-01", "13-25-00"],
-                "Passing: Lunch/7": ["13-25-01", "13-35-00"],
-                "7th Period": ["13-35-01", "15-05-00"]
+                "Passing (Lunch / Seventh Period)": ["13-25-01", "13-35-00"],
+                "Seventh Period": ["13-35-01", "15-05-00"]
             },
             "FRI": {
-                "4th Period": ["08-00-00", "10-05-00"],
-                "Passing: 4/Academy": ["10-05-01", "10-15-00"],
+                "Staff Meeting": ["07-30-00", "08-30-00"],
+                "Passing (Staff Meeting / Fourth Periods)": [
+                    "08-30-01",
+                    "08-35-00"
+                ],
+                "Fourth Period": ["08-35-01", "10-05-00"],
+                "Passing (Fourth Period / Academy)": ["10-05-01", "10-15-00"],
                 "Academy": ["10-15-01", "11-10-00"],
                 "Brunch": ["11-10-01", "11-15-00"],
-                "Passing: Brunch/5": ["11-15-01", "11-25-00"],
-                "5th Period": ["11-25-01", "12-55-00"],
+                "Passing (Brunch / Fifth Period)": ["11-15-01", "11-25-00"],
+                "Fifth Period": ["11-25-01", "12-55-00"],
                 "Lunch": ["12-55-01", "13-25-00"],
-                "Passing: Lunch/6": ["13-25-01", "13-35-00"],
-                "6th Period": ["13-35-01", "15-05-00"]
-            }
-        }
-    },
-    "ca-auhsd-hys": {
-        "name": "AUHSD Hybrid Schedule",
-        "shortName": "AUHSD Hybrid",
-        "icon": "mdiSchoolOutline",
-        "color": "#343254",
-        "schedule": {
-            "MON": {
-                "Cohort Academy": ["09-00-00", "09-45-00"],
-                "Passing (Cohort Academy / First Period)": [
-                    "09-45-01",
-                    "09-59-59"
-                ],
-                "First Period": ["10-00-00", "10-40-00"],
-                "Passing (First / Second Periods)": ["10-40-01", "10-44-59"],
-                "Second Period": ["10-45-00", "11-25-00"],
-                "Passing (Second / Third Periods)": ["11-25-01", "11-29-59"],
-                "Third Period": ["11-30-00", "12-10-00"],
-                "Lunch": ["12-10-01", "12-39-59"],
-                "Fourth Period": ["12-40-00", "13-20-00"],
-                "Passing (Fourth / Fifth Periods)": ["13-20-01", "13-24-59"],
-                "Fifth Period": ["13-25-00", "14-05-00"],
-                "Passing (Fifth / Sixth Periods)": ["14-05-01", "14-09-59"],
-                "Sixth Period": ["14-10-00", "14-50-00"],
-                "Passing (Sixth / Seventh Periods)": ["14-50-01", "14-54-59"],
-                "Seventh Period": ["14-55-00", "15-35-00"]
-            },
-            "TUE": {
-                "First Period": ["08-30-00", "09-45-00"],
-                "Brunch": ["09-45-01", "10-05-00"],
-                "Second Period": ["10-05-01", "11-20-00"],
-                "Passing (Second Period / Academy/Lunch 1)": [
-                    "11-20-01",
-                    "11-29-59"
-                ],
-                "Academy (1) / Lunch (1)": ["11-30-00", "11-59-59"],
-                "Passing (Academy/Lunch 1 / Academy/Lunch 2)": [
-                    "12-00-00",
-                    "12-04-59"
-                ],
-                "Academy (2) / Lunch (2)": ["12-05-00", "12-34-59"],
-                "Passing (Academy/Lunch 2 / Third Period)": [
-                    "12-35-00",
-                    "12-39-59"
-                ],
-                "Third Period": ["12-40-00", "13-55-00"],
-                "Passing (Third / Seventh Periods)": ["13-55-01", "14-04-59"],
-                "Seventh Period": ["14-05-00", "15-20-00"]
-            },
-            "WED": {
-                "First Period": ["08-30-00", "09-45-00"],
-                "Brunch": ["09-45-01", "10-05-00"],
-                "Second Period": ["10-05-01", "11-20-00"],
-                "Passing (Second Period / Academy/Lunch 1)": [
-                    "11-20-01",
-                    "11-29-59"
-                ],
-                "Academy (1) / Lunch (1)": ["11-30-00", "11-59-59"],
-                "Passing (Academy/Lunch 1 / Academy/Lunch 2)": [
-                    "12-00-00",
-                    "12-04-59"
-                ],
-                "Academy (2) / Lunch (2)": ["12-05-00", "12-34-59"],
-                "Passing (Academy/Lunch 2 / Third Period)": [
-                    "12-35-00",
-                    "12-39-59"
-                ],
-                "Third Period": ["12-40-00", "13-55-00"],
-                "Passing (Third / Seventh Periods)": ["13-55-01", "14-04-59"],
-                "Seventh Period": ["14-05-00", "15-20-00"]
-            },
-            "THU": {
-                "Fourth Period": ["08-30-00", "09-45-00"],
-                "Brunch": ["09-45-01", "10-05-00"],
-                "Fifth Period": ["10-05-01", "11-20-00"],
-                "Passing (Fifth Period / Academy/Lunch 1)": [
-                    "11-20-01",
-                    "11-29-59"
-                ],
-                "Academy (1) / Lunch (1)": ["11-30-00", "11-59-59"],
-                "Passing (Academy/Lunch 1 / Academy/Lunch 2)": [
-                    "12-00-00",
-                    "12-04-59"
-                ],
-                "Academy (2) / Lunch (2)": ["12-05-00", "12-34-59"],
-                "Passing (Academy/Lunch 2 / Sixth Period)": [
-                    "12-35-00",
-                    "12-39-59"
-                ],
-                "Sixth Period": ["12-40-00", "13-55-00"],
-                "Passing (Sixth / Zero Periods)": ["13-55-01", "14-04-59"],
-                "Zero Period": ["14-05-00", "15-20-00"]
-            },
-            "FRI": {
-                "Fourth Period": ["08-30-00", "09-45-00"],
-                "Brunch": ["09-45-01", "10-05-00"],
-                "Fifth Period": ["10-05-01", "11-20-00"],
-                "Passing (Fifth Period / Academy/Lunch 1)": [
-                    "11-20-01",
-                    "11-29-59"
-                ],
-                "Academy (1) / Lunch (1)": ["11-30-00", "11-59-59"],
-                "Passing (Academy/Lunch 1 / Academy/Lunch 2)": [
-                    "12-00-00",
-                    "12-04-59"
-                ],
-                "Academy (2) / Lunch (2)": ["12-05-00", "12-34-59"],
-                "Passing (Academy/Lunch 2 / Sixth Period)": [
-                    "12-35-00",
-                    "12-39-59"
-                ],
-                "Sixth Period": ["12-40-00", "13-55-00"],
-                "Passing (Sixth / Zero Periods)": ["13-55-01", "14-04-59"],
-                "Zero Period": ["14-05-00", "15-20-00"]
+                "Passing (Lunch / Sixth Period)": ["13-25-01", "13-35-00"],
+                "Sixth Period": ["13-35-01", "15-05-00"]
             }
         }
     }


### PR DESCRIPTION
- Replace period start/end `String`s with `DateComponents`
- `DateComponents` are set at the time of JSON parsing to minimize conversion errors later on
- Use new schedules JSON



<img width="441" alt="Next Period is shown" src="https://user-images.githubusercontent.com/49819455/139174541-762c2c63-db5a-4459-9d7d-c170133c4e53.png">


